### PR TITLE
ensure trinket in slot 1 is removable on inv clear

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -509,12 +509,14 @@ local function RemoveAllItems(player)
         end
     end
 
-    for i = 0, 1 do
-        local trinket = player:GetTrinket(i)
+    local trinkets = { player:GetTrinket(0), player:GetTrinket(1) }
+    player:AddCollectible(CollectibleType.COLLECTIBLE_MOMS_PURSE, 0, false)
+    for _, trinket in ipairs(trinkets) do
         if trinket and trinket > 0 then
             player:TryRemoveTrinket(trinket)
         end
     end
+    player:RemoveCollectible(CollectibleType.COLLECTIBLE_MOMS_PURSE)
 
     local active = player:GetActiveItem()
     if active > 0 then


### PR DESCRIPTION
If player 1 has two trinkets, the new player can't remove the trinket in slot 1 without the proper max trinket level.
Give the player mom's purse to facilitate this temporarily then remove.
Unfortunately the game also is tricked into thinking there is no trinket in slot 1 if it's given then the slot is checked,
so first grab trinkets, then add mom's purse, then remove trinkets, then remove purse